### PR TITLE
Rewrite lazy import mechanism to support submodules

### DIFF
--- a/tables_io/convUtils.py
+++ b/tables_io/convUtils.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import numpy as np
 
 from .lazy_modules import pd, apTable, fits
-from .lazy_modules import HAS_ASTROPY, HAS_PANDAS
 
 from .arrayUtils import forceToPandables
 
@@ -30,9 +29,6 @@ def dataFrameToApTable(df):
     tab : `astropy.table.Table`
         The table
     """
-    if not HAS_ASTROPY:  #pragma: no cover
-        raise ImportError("Astropy is not available, can't make astropy tables")
-
     o_dict = OrderedDict()
     for colname in df.columns:
         col = df[colname]
@@ -246,9 +242,6 @@ def apTableToDataFrame(tab):
     df :  `pandas.DataFrame`
         The dataframe
     """
-    if not HAS_PANDAS:  #pragma: no cover
-        raise ImportError("pandas is not available, can't make DataFrame")
-
     o_dict = OrderedDict()
     for colname in tab.columns:
         col = tab[colname]

--- a/tables_io/ioUtils.py
+++ b/tables_io/ioUtils.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 import numpy as np
 
 from .lazy_modules import pd, pq, h5py, apTable, fits
-from .lazy_modules import HAS_TABLES, HAS_HDF5
 
 from .arrayUtils import getGroupInputDataLength
 
@@ -509,9 +508,6 @@ def writeApTablesToHdf5(tables, filepath, **kwargs):
 
     kwargs are passed to `astropy.table.Table` call.
     """
-    if not HAS_HDF5:  #pragma: no cover
-        raise ImportError("h5py is not available, can't save to hdf5")
-
     for k, v in tables.items():
         v.write(filepath, path=k, append=True, format='hdf5', **kwargs)
 
@@ -668,11 +664,6 @@ def readHdf5ToDataFrame(filepath, key=None):
     df : `pandas.DataFrame`
         The dataframe
     """
-    if not HAS_HDF5:  #pragma: no cover
-        raise ImportError("h5py is not available, can't read hdf5")
-    if not HAS_TABLES:  #pragma: no cover
-        raise ImportError("tables is not available, can't read hdf5 to dataframe")
-
     return pd.read_hdf(filepath, key)
 
 
@@ -694,8 +685,6 @@ def readH5ToDataFrames(filepath):
     We are using the file suffix 'h5' to specify 'hdf5' files written from DataFrames using `pandas`
     They have a different structure than 'hdf5' files written with `h5py` or `astropy.table`
     """
-    if not HAS_TABLES:  #pragma: no cover
-        raise ImportError("tables is not available, can't read hdf5 to dataframe")
     fin = h5py.File(filepath)
     return OrderedDict([(key, readHdf5ToDataFrame(filepath, key=key)) for key in fin.keys()])
 
@@ -712,11 +701,6 @@ def writeDataFramesToH5(dataFrames, filepath):
     filepath: `str`
         Path to output file
     """
-    if not HAS_HDF5:  #pragma: no cover
-        raise ImportError("h5py is not available, can't write hdf5")
-    if not HAS_TABLES:  #pragma: no cover
-        raise ImportError("tables is not available, can't write hdf5")
-
     for key, val in dataFrames.items():
         val.to_hdf(filepath, key)
 

--- a/tables_io/types.py
+++ b/tables_io/types.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping, Iterable
 
 import numpy as np
 
-from .lazy_modules import apTable, pd
 from .arrayUtils import arrayLength
 
 # Tabular data formats
@@ -79,6 +78,20 @@ ALLOWED_FORMATS = OrderedDict([
     (PD_DATAFRAME, [PANDAS_PARQUET, PANDAS_HDF5])])
 
 
+def isDataFrame(obj):
+    for c in obj.__class__.__mro__:
+        if c.__name__ == "DataFrame" and c.__module__ == "pandas.core.frame":
+            return True
+    return False
+
+def isApTable(obj):
+    for c in obj.__class__.__mro__:
+        if c.__name__ == "Table" and c.__module__ == "astropy.table.table":
+            return True
+    return False
+
+
+
 def tableType(obj):
     """ Identify the type of table we have
 
@@ -98,10 +111,10 @@ def tableType(obj):
 
     IndexError : One of the columns in a Mapping is the wrong length
     """
-    if isinstance(obj, apTable.Table):
-        return AP_TABLE
-    if isinstance(obj, pd.DataFrame):
+    if isDataFrame(obj):
         return PD_DATAFRAME
+    if isApTable(obj):
+        return AP_TABLE
     if isinstance(obj, np.recarray):
         return NUMPY_RECARRAY
     if not isinstance(obj, Mapping):


### PR DESCRIPTION
In the current lazy importing mechanism both `pyarrow` and `astropy` are always imported, because the built-in python LazyLoader doesn't seem to work with sub-modules - it always imports the parent.

This replaces that mechanism with one that doesn't load the parent, at the cost of not returning an actual module object, just one that wraps the `__getattr__` and `__dir__` methods of the real module (which it imports only when needed).  That might cause problems if used more widely, but seems okay in the limited way we use it here.

This also involved removing the various `HAS_*` variables, since we can't tell if the module is available until we actually try loading. Instead the corresponding errors will happen when we try to actually use the module, e.g. by running `h5py.File`.

Finally, I also wanted to stop the `tableType` from triggering the imports of pandas and astropy (or failing if they were not present), so I added utility functions that examine the inheritance tree of an obejct to check if they are (descended from) data frames or AP tables.