### PR TITLE
Issue/54/extend input types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dev = [
     "pytest",
     "pytest-cov",
     "flake8",
+    "jax",
+    "jaxlib",
 ]
 
 [build-system]
@@ -112,7 +114,7 @@ addopts = [
     "--cov=tables_io",
     "--cov-report=html"
 ]
-flake8-ignore = "E203"
+#flake8-ignore = "E203"
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy>=1.21.0",
     "astropy",
-    "h5py",
+    "h5py>=2.9",
     "pandas",
     "pyarrow",
     "tables",
@@ -30,7 +30,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "h5py>=2.9=mpi*",
     "mpi4py",
     "coverage",
     "pylint",

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -587,11 +587,12 @@ def readHdf5GroupToDict(hg, start=None, end=None):
 
 def writeDictToHdf5(odict, filepath, groupname, **kwargs):
     """
-    Writes a dictionary of `numpy.array` to a single hdf5 file
+    Writes a dictionary of `numpy.array` or `jaxlib.xla_extension.DeviceArray`
+    to a single hdf5 file
 
     Parameters
     ----------
-    odict : `Mapping`, (`str`, `numpy.array`)
+    odict : `Mapping`, (`str`, {`numpy.array`, `jaxlib.xla_extension.DeviceArray`})
         The data being written
 
     filepath: `str`

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -592,7 +592,7 @@ def writeDictToHdf5(odict, filepath, groupname, **kwargs):
 
     Parameters
     ----------
-    odict : `Mapping`, (`str`, {`numpy.array`, `jaxlib.xla_extension.DeviceArray`})
+    odict : `Mapping`, (`str`, `numpy.array` or `jaxlib.xla_extension.DeviceArray`)
         The data being written
 
     filepath: `str`

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -608,7 +608,14 @@ def writeDictToHdf5(odict, filepath, groupname, **kwargs):
         group = fout.create_group(groupname)
     for key, val in odict.items():
         try:
-            group.create_dataset(key, dtype=val.dtype, data=val.data)
+            if isinstance(val, np.ndarray):
+                group.create_dataset(key, dtype=val.dtype, data=val.data)
+            else:
+                # In the future, it may be better to specifically case for
+                # jaxlib.xla_extension.DeviceArray here. For now, we're
+                # resorting to duck typing so we don't have to import jax just
+                # to check the type.
+                group.create_dataset(key, dtype=val.dtype, data=val.device_buffer)
         except Exception as msg:  #pragma: no cover
             print(f"Warning.  Failed to convert column {str(msg)}")
     fout.close()


### PR DESCRIPTION
Adding support for writing data of type `jaxlib.xla_extension.DeviceArray` to hdf5s, spurred by such datasets being created and passed into table_io's `writeDictToHdf5` when running RAIL's Goldenspike pipeline example notebook.