### PR TITLE
PROD move to conda in CI job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,10 +41,11 @@ jobs:
           "h5py>=2.9" \
           "pandas" \
           "pyarrow" \
-          "tables" \
+          "pytables" \
           mpi4py \
           "hdf5=*=*mpi_openmpi*" \
           pylint pytest pytest-cov jupyter \
+          pip setuptools \
           "coverage" \
           "flake8" \
           "jax"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,29 +13,42 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
+        channels: conda-forge,defaults
+        channel-priority: strict
+        show-channel-urls: true
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
+        use-mamba: true
+
     - name: Install dependencies
       run: |
-        sudo apt install -y libopenmpi-dev libhdf5-mpi-dev
-        python -m pip install --upgrade pip
-        python -m pip install pylint pytest pytest-cov
-        python -m pip install jupyter
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        CC="mpicc" HDF5_MPI="ON" pip install --upgrade --force-reinstall --no-binary=h5py h5py
-        pip install .
-        pip install .[dev]
-      env:
-        CC: mpicc
-        HDF5_MPI: ON
+        mamba install \
+          "numpy>=1.21.0" \
+          "astropy" \
+          "h5py>=2.9" \
+          "pandas" \
+          "pyarrow" \
+          "tables" \
+          mpi4py \
+          "hdf5=*=*mpi_openmpi*" \
+          pylint pytest pytest-cov jupyter \
+          "coverage" \
+          "flake8" \
+          "jax"
+        pip install --no-deps .
     - name: Lint with pylint
       run: |
         # stop the build if there are Pylint errors

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,7 +38,7 @@ jobs:
         mamba install \
           "numpy>=1.21.0" \
           "astropy" \
-          "h5py>=2.9" \
+          "h5py>=2.9=*mpi_openmpi*" \
           "pandas" \
           "pyarrow" \
           "pytables" \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
@@ -32,23 +31,10 @@ jobs:
         miniforge-version: latest
         miniforge-variant: Mambaforge
         use-mamba: true
-
+        environment-file: environment.yml
+        activate-environment: tables_io
     - name: Install dependencies
       run: |
-        mamba install \
-          "numpy>=1.21.0" \
-          "astropy" \
-          "h5py>=2.9=*mpi_openmpi*" \
-          "pandas" \
-          "pyarrow" \
-          "pytables" \
-          mpi4py \
-          "hdf5=*=*mpi_openmpi*" \
-          pylint pytest pytest-cov jupyter \
-          pip setuptools \
-          "coverage" \
-          "flake8" \
-          "jax"
         pip install --no-deps .
     - name: Lint with pylint
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: tables_io
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy>=1.21.0
+  - astropy
+  - h5py>=2.9=*mpi_openmpi*
+  - pandas
+  - pyarrow
+  - pytables
+  - mpi4py
+  - hdf5=*=*mpi_openmpi*
+  - pylint
+  - pytest
+  - pytest-cov
+  - jupyter
+  - pip
+  - setuptools
+  - coverage
+  - flake8
+  - jax


### PR DESCRIPTION
This PR moves the CI job to conda. We could do more by making env files etc., but this is simple enough that it doesn't seem worth it.