### PR TITLE
Issue/61/parquet suffixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ effectively 5 and a half different file formats
     df.to_hdf(filepath, key)
 
     
-5. 'parquet', as used to store pandas datafames, e.g., as produced by:
+5. 'parquet' ('parq' or 'pq' are also valid file suffixes), as used to store pandas datafames, e.g., as produced by:
 
    
 .. code-block:: python

--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - coverage
   - flake8
   - jax
+  - jaxlib

--- a/src/tables_io/types.py
+++ b/src/tables_io/types.py
@@ -47,6 +47,8 @@ FILE_FORMAT_SUFFIXS = OrderedDict([
     ('hdf5', NUMPY_HDF5),
     ('fit', NUMPY_FITS),
     ('h5', PANDAS_HDF5),
+    ('parquet', PANDAS_PARQUET),
+    ('parq', PANDAS_PARQUET),
     ('pq', PANDAS_PARQUET)])
 
 DEFAULT_TABLE_KEY = OrderedDict([
@@ -55,6 +57,8 @@ DEFAULT_TABLE_KEY = OrderedDict([
     ('hdf5', None),
     ('fit', ''),
     ('h5', 'data'),
+    ('parquet', ''),
+    ('parq', ''),
     ('pq', '')])
 
 FILE_FORMATS = OrderedDict([(val, key) for key, val in FILE_FORMAT_NAMES.items()])


### PR DESCRIPTION
I successfully tested the read function using .parquet and .parq files.
However, I was not able to make pytest work with the test files, but I suspect the reason is not related to my commits. 
One source of error was the lack of a dependency (jaxlib). So I included it in the requirements list. 
Then the next pytest errors seem to be due to test data not being found. 

 
 