### PR TITLE
Preserve user-specified file extensions when loading and saving

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -81,8 +81,6 @@ class IoTestCase(unittest.TestCase):  #pylint: disable=too-many-instance-attribu
 
         basepath_native = "%s_native" % basepath
         filepath_native = write(obj_c, basepath_native)
-        if keys is not None:
-            filepath_native += ".pq"
         self._files.append(filepath_native)
         obj_r_native = read(filepath_native, tType=tType, keys=keys)
         table_r_native = convert(obj_r_native, types.AP_TABLE)


### PR DESCRIPTION
Fixes issue #61.

This patch changes the behavior of the read*() and write*() functions to allow passing file names with different suffixes.

As a consequence, the patch also fixes the FileNotFoundError exception when loading files with the ".parq" and ".parquet" suffixes.

Overall, the new behavior of the functions is the following:

- Passing file names without suffixes: behavior stays the same (file format is deduced by the data type where applicable).
- Passing file names with the default suffixes for some corresponding table type: behavior stays the same.
- Passing file names with non-default suffixes for some corresponding table type: user-defined suffix is now preserved and is not overwritten anymore.