### PR TITLE
Allow read to take a list of columns

### DIFF
--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -397,12 +397,16 @@ def iterPqToDataFrame(filepath,chunk_size=100_000,columns=None,**kwargs):
 
     Parameters
     ----------
-      filepath: input file name (str)
+    filepath: input file name (str)
+    columns : `list` (`str`) or `None`
+        Names of the columns to read, `None` will read all the columns
+    **kwargs : additional arguments to pass to the native file reader
 
     Returns
     -------
     output:
         iterator chunk
+
 
     Returns `tuple`
         start: start index (int)
@@ -738,7 +742,7 @@ def writeDataFramesToH5(dataFrames, filepath):
 
 ### II E.  Reading and Writing `pandas.DataFrame` to/from `parquet`
 
-def readPqToDataFrame(filepath):
+def readPqToDataFrame(filepath, columns=None, **kwargs):
     """
     Reads a `pandas.DataFrame` object from an parquet file.
 
@@ -747,12 +751,16 @@ def readPqToDataFrame(filepath):
     filepath: `str`
         Path to input file
 
+    columns : `list` (`str`) or `None`
+        Names of the columns to read, `None` will read all the columns
+    **kwargs : additional arguments to pass to the native file reader
+
     Returns
     -------
     df : `pandas.DataFrame`
         The data frame
     """
-    return pd.read_parquet(filepath, engine='pyarrow')
+    return pd.read_parquet(filepath, engine='pyarrow', columns=columns, **kwargs)
 
 
 def writeDataFramesToPq(dataFrames, filepath, **kwargs):
@@ -772,7 +780,7 @@ def writeDataFramesToPq(dataFrames, filepath, **kwargs):
         _ = v.to_parquet(f"{filepath}{k}.pq", **kwargs)
 
 
-def readPqToDataFrames(basepath, keys=None, allow_missing_keys=False):
+def readPqToDataFrames(basepath, keys=None, allow_missing_keys=False, columns=None, **kwargs):
     """
     Reads `pandas.DataFrame` objects from an parquet file.
 
@@ -787,6 +795,10 @@ def readPqToDataFrames(basepath, keys=None, allow_missing_keys=False):
     allow_missing_keys: `bool`
         If False will raise FileNotFoundError if a key is missing
 
+    columns : `list` (`str`) or `None`
+        Names of the columns to read, `None` will read all the columns
+    **kwargs : additional arguments to pass to the native file reader
+
     Returns
     -------
     tables : `OrderedDict` of `pandas.DataFrame`
@@ -797,17 +809,17 @@ def readPqToDataFrames(basepath, keys=None, allow_missing_keys=False):
     dataframes = OrderedDict()
     for key in keys:
         try:
-            dataframes[key] = readPqToDataFrame(f"{basepath}{key}.pq")
+            dataframes[key] = readPqToDataFrame(f"{basepath}{key}.pq", columns=columns, **kwargs)
         except FileNotFoundError as msg:  #pragma: no cover
             if allow_missing_keys:
                 continue
-            raise FileNotFoundError from msg
+            raise msg
     return dataframes
 
 
 ### II F.  Reading and Writing to `OrderedDict`, (`str`, `numpy.array`)
 
-def readPqToDict(filepath, columns=None):
+def readPqToDict(filepath, columns=None, **kwargs):
     """ Open a parquet file and return a dictionary of `numpy.array`
 
     Parameters
@@ -817,13 +829,14 @@ def readPqToDict(filepath, columns=None):
 
     columns : `list` (`str`) or `None`
         Names of the columns to read, `None` will read all the columns
+    **kwargs : additional arguments to pass to the native file reader
 
     Returns
     -------
     tab : `OrderedDict` (`str` : `numpy.array`)
        The data
     """
-    tab = pq.read_table(filepath, columns=columns)
+    tab = pq.read_table(filepath, columns=columns, **kwargs)
     return OrderedDict([(c_name, col.to_numpy()) for c_name, col in zip(tab.column_names, tab.itercolumns())])
 
 
@@ -906,7 +919,7 @@ def io_open(filepath, fmt=None, **kwargs):
     raise TypeError(f"Unsupported FileType {fType}")  #pragma: no cover
 
 
-def readNative(filepath, fmt=None, keys=None, allow_missing_keys=False):
+def readNative(filepath, fmt=None, keys=None, allow_missing_keys=False, **kwargs):
     """ Read a file to the corresponding table type
 
     Parameters
@@ -919,6 +932,7 @@ def readNative(filepath, fmt=None, keys=None, allow_missing_keys=False):
         For parquet files we must specify with keys to read, as each is in its own file
     allow_missing_keys : `bool`
         If False will raise FileNotFoundError if a key is missing
+    **kwargs : additional arguments to pass to the native file reader
 
     Returns
     -------
@@ -939,11 +953,11 @@ def readNative(filepath, fmt=None, keys=None, allow_missing_keys=False):
         return readH5ToDataFrames(filepath)
     if fType == PANDAS_PARQUET:
         basepath = os.path.splitext(filepath)[0]
-        return readPqToDataFrames(basepath, keys, allow_missing_keys)
+        return readPqToDataFrames(basepath, keys, allow_missing_keys, **kwargs)
     raise TypeError(f"Unsupported FileType {fType}")  #pragma: no cover
 
 
-def read(filepath, tType=None, fmt=None, keys=None, allow_missing_keys=False):
+def read(filepath, tType=None, fmt=None, keys=None, allow_missing_keys=False, **kwargs):
     """ Read a file to the corresponding table type
 
     Parameters
@@ -955,9 +969,10 @@ def read(filepath, tType=None, fmt=None, keys=None, allow_missing_keys=False):
     fmt : `str` or `None`
         File format, if `None` it will be taken from the file extension
     keys : `list` or `None`
-        For parquet files we must specify with keys to read, as each is in its own file
+        For parquet files we must specify which keys to read, as each is in its own file
     allow_missing_keys : `bool`
         If False will raise FileNotFoundError if a key is missing
+    **kwargs : additional arguments to pass to the native file reader
 
     Returns
     -------
@@ -965,7 +980,7 @@ def read(filepath, tType=None, fmt=None, keys=None, allow_missing_keys=False):
         The data
 
     """
-    odict = readNative(filepath, fmt, keys, allow_missing_keys)
+    odict = readNative(filepath, fmt, keys, allow_missing_keys, **kwargs)
     if len(odict) == 1:
         for defName in ['', None, '__astropy_table__', 'data']:
             if defName in odict:

--- a/src/tables_io/testUtils.py
+++ b/src/tables_io/testUtils.py
@@ -19,7 +19,7 @@ def check_deps(deps=None):
     return not missing
 
 
-def compare_tables(t1, t2):
+def compare_tables(t1, t2, columns=None):
     """ Compare all the tables in two `astropy.table.Table`)
 
     Parameters
@@ -38,6 +38,9 @@ def compare_tables(t1, t2):
     -----
     For now this explicitly flattens each of the columns, to avoid issues with shape
     """
+    if columns:
+        t1.keep_columns(columns)
+        t2.keep_columns(columns)
     if sorted(t1.colnames) != sorted(t2.colnames):  #pragma: no cover
         return False
     for cname in t1.colnames:
@@ -48,7 +51,7 @@ def compare_tables(t1, t2):
     return True
 
 
-def compare_table_dicts(d1, d2, strict=False):
+def compare_table_dicts(d1, d2, strict=False, columns=None):
     """ Compare all the tables in two `OrderedDict`, (`str`, `astropy.table.Table`)
 
     Parameters
@@ -72,7 +75,7 @@ def compare_table_dicts(d1, d2, strict=False):
         if strict:  #pragma: no cover
             identical &= apDiffUtils.report_diff_values(v, vv)
         else:  #pragma: no cover
-            identical &= compare_tables(v, vv)
+            identical &= compare_tables(v, vv, columns=columns)
     return identical
 
 

--- a/src/tables_io/types.py
+++ b/src/tables_io/types.py
@@ -123,7 +123,7 @@ def tableType(obj):
         return NUMPY_RECARRAY
     if not isinstance(obj, Mapping):
         raise TypeError(f"Object of type {type(obj)} is not one of the supported types"
-                        "{list(TABULAR_FORMAT_NAMES.keys())}")
+                        f"{list(TABULAR_FORMAT_NAMES.keys())}")
 
     nRow = None
     for key, val in obj.items():

--- a/src/tables_io/types.py
+++ b/src/tables_io/types.py
@@ -76,7 +76,7 @@ NATIVE_TABLE_TYPE = OrderedDict([(val, key) for key, val in NATIVE_FORMAT.items(
 
 # Allowed formats to write various table types
 ALLOWED_FORMATS = OrderedDict([
-    (AP_TABLE, [ASTROPY_HDF5, ASTROPY_HDF5]),
+    (AP_TABLE, [ASTROPY_FITS, ASTROPY_HDF5]),
     (NUMPY_DICT, [NUMPY_HDF5]),
     (NUMPY_RECARRAY, [ASTROPY_FITS]),
     (PD_DATAFRAME, [PANDAS_PARQUET, PANDAS_HDF5])])
@@ -206,4 +206,4 @@ def fileType(filepath, fmt=None):
         return FILE_FORMAT_SUFFIXS[fmt]
     except KeyError as msg:
         raise KeyError(f"Unknown file format {fmt}, supported types are"
-                       "{list(FILE_FORMAT_SUFFIXS.keys())}") from msg
+                       f"{list(FILE_FORMAT_SUFFIXS.keys())}") from msg

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,49 +12,59 @@ from tables_io.lazy_modules import apTable, jnp, h5py, pd, pq
 
 
 @pytest.mark.skipif(not check_deps([apTable, h5py, pq, jnp]), reason="Missing an IO package")
-class IoTestCase(unittest.TestCase):  #pylint: disable=too-many-instance-attributes
-    """ Test the utility functions """
+class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
+    """Test the utility functions"""
 
     def setUp(self):
         """
         Make any objects that are used in multiple tests.
         """
         self._tables = make_test_data()
-        self._table = self._tables['data']
+        self._table = self._tables["data"]
         self._files = []
 
     def tearDown(self):
-        """ Clean up any mock data files created by the tests. """
+        """Clean up any mock data files created by the tests."""
         for ff in self._files:
             if os.path.exists(ff):
                 os.unlink(ff)
 
-    def _do_loopback(self, tType, basepath, fmt,**kwargs):
-        """ Utility function to do loopback tests """
+    def _do_loopback(self, tType, basepath, fmt, **kwargs):
+        """Utility function to do loopback tests"""
         odict_c = convert(self._tables, tType)
         filepath = write(odict_c, basepath, fmt)
         self._files.append(filepath)
         odict_r = read(filepath, tType=tType, fmt=fmt, **kwargs)
         tables_r = convert(odict_r, types.AP_TABLE)
         assert compare_table_dicts(self._tables, tables_r, **kwargs)
-   
-    def _do_loopback_with_keys(self, tType, basepath, fmt, keys, **kwargs):
-        """ Utility function to do loopback tests """
+
+    def _do_loopback_with_keys(self, tType, basepath, fmt, keys, columns=None, **kwargs):
+        """Utility function to do loopback tests in formats that require keyed files"""
         odict_c = convert(self._tables, tType)
         filepath = write(odict_c, basepath, fmt)
         expected_tables = {}
         for key in keys:
             self._files.append("%s%s.%s" % (basepath, key, fmt))
             expected_tables[key] = self._tables[key]
-        odict_r = read(filepath, tType=tType, fmt=fmt, keys=keys, **kwargs)
+        odict_r = read(filepath, tType=tType, fmt=fmt, keys=keys, columns=columns, **kwargs)
         tables_r = convert(odict_r, types.AP_TABLE)
-        if pd.api.types.is_dict_like(tables_r):
-            assert compare_table_dicts(expected_tables, tables_r, **kwargs)
+        column_list = None
+        if pd.api.types.is_dict_like(columns):
+            for key in columns.keys():
+                if pd.api.types.is_dict_like(tables_r):
+                    assert compare_tables(expected_tables[key], tables_r[key], columns=columns[key], **kwargs)
+                else:
+                    assert compare_tables(
+                        list(expected_tables.values())[0], tables_r, columns=columns[key], **kwargs
+                    )
         else:
-            assert compare_tables(list(expected_tables.values())[0], tables_r, **kwargs)         
+            if pd.api.types.is_dict_like(tables_r):
+                assert compare_table_dicts(expected_tables, tables_r, columns=columns, **kwargs)
+            else:
+                assert compare_tables(list(expected_tables.values())[0], tables_r, columns=columns, **kwargs)
 
     def _do_loopback_jax(self, basepath, fmt, keys=None, **kwargs):
-        """ Utility function to do loopback tests writing data as a jax array """
+        """Utility function to do loopback tests writing data as a jax array"""
         odict_c = convert(self._tables, types.NUMPY_DICT)
         for key, val in odict_c["data"].items():
             odict_c["data"][key] = jnp.array(val)
@@ -69,7 +79,7 @@ class IoTestCase(unittest.TestCase):  #pylint: disable=too-many-instance-attribu
         assert compare_table_dicts(self._tables, tables_r, **kwargs)
 
     def _do_loopback_single(self, tType, basepath, fmt, keys=None, **kwargs):
-        """ Utility function to do loopback tests """
+        """Utility function to do loopback tests"""
         obj_c = convert(self._table, tType)
         filepath = write(obj_c, basepath, fmt)
         try:
@@ -99,9 +109,8 @@ class IoTestCase(unittest.TestCase):  #pylint: disable=too-many-instance-attribu
         table_r_native = convert(obj_r_native, types.AP_TABLE)
         assert compare_tables(self._table, table_r_native, **kwargs)
 
-
     def _do_iterator(self, filepath, tType, expectFail=False, chunk_size=50, **kwargs):
-        """ Test the chunk iterator """
+        """Test the chunk iterator"""
         dl = []
         try:
             for _, _, data in iterator(filepath, tType=tType, chunk_size=chunk_size, **kwargs):
@@ -115,80 +124,81 @@ class IoTestCase(unittest.TestCase):  #pylint: disable=too-many-instance-attribu
                 raise msg
 
     def _do_open(self, filepath, in_context=True):
-        """  """
+        """ """
         if not in_context:
             f = io_open(filepath)
             assert f
             return
         with io_open(filepath) as f:
             assert f
-        
+
     def testFitsLoopback(self):
-        """ Test writing / reading to FITS """
-        self._do_loopback(types.AP_TABLE, 'test_out', 'fits')
-        self._do_loopback_single(types.AP_TABLE, 'test_out_single', 'fits')
-        self._do_iterator('test_out_single.fits', types.AP_TABLE, True)
-        self._do_open('test_out_single.fits')
-        self._do_open('test_out.fits')
-        
+        """Test writing / reading to FITS"""
+        self._do_loopback(types.AP_TABLE, "test_out", "fits")
+        self._do_loopback_single(types.AP_TABLE, "test_out_single", "fits")
+        self._do_iterator("test_out_single.fits", types.AP_TABLE, True)
+        self._do_open("test_out_single.fits")
+        self._do_open("test_out.fits")
+
     def testRecarrayLoopback(self):
-        """ Test writing / reading to FITS """
-        self._do_loopback(types.NUMPY_RECARRAY, 'test_out', 'fit')
-        self._do_loopback_single(types.NUMPY_RECARRAY, 'test_out_single', 'fit')
-        self._do_iterator('test_out_single.fit', types.NUMPY_RECARRAY, True)
-        self._do_open('test_out_single.fit')
-        self._do_open('test_out.fit')
-        
+        """Test writing / reading to FITS"""
+        self._do_loopback(types.NUMPY_RECARRAY, "test_out", "fit")
+        self._do_loopback_single(types.NUMPY_RECARRAY, "test_out_single", "fit")
+        self._do_iterator("test_out_single.fit", types.NUMPY_RECARRAY, True)
+        self._do_open("test_out_single.fit")
+        self._do_open("test_out.fit")
+
     def testHf5Loopback(self):
-        """ Test writing / reading astropy tables to HDF5 """
-        self._do_loopback(types.AP_TABLE, 'test_out', 'hf5')
-        self._do_loopback_single(types.AP_TABLE, 'test_out_single', 'hf5')
-        self._do_iterator('test_out_single.hf5', types.AP_TABLE, True, chunk_size=50)
-        self._do_open('test_out_single.hf5')
-        self._do_open('test_out.hf5')
-        
+        """Test writing / reading astropy tables to HDF5"""
+        self._do_loopback(types.AP_TABLE, "test_out", "hf5")
+        self._do_loopback_single(types.AP_TABLE, "test_out_single", "hf5")
+        self._do_iterator("test_out_single.hf5", types.AP_TABLE, True, chunk_size=50)
+        self._do_open("test_out_single.hf5")
+        self._do_open("test_out.hf5")
+
     def testHdf5Loopback(self):
-        """ Test writing / reading numpy arrays to HDF5 """
-        self._do_loopback(types.NUMPY_DICT, 'test_out', 'hdf5')
-        self._do_loopback_single(types.NUMPY_DICT, 'test_out_single', 'hdf5')
-        self._do_iterator('test_out_single.hdf5', types.NUMPY_DICT, False, chunk_size=50)
-        self._do_open('test_out_single.hdf5')
-        self._do_open('test_out.hdf5')
+        """Test writing / reading numpy arrays to HDF5"""
+        self._do_loopback(types.NUMPY_DICT, "test_out", "hdf5")
+        self._do_loopback_single(types.NUMPY_DICT, "test_out_single", "hdf5")
+        self._do_iterator("test_out_single.hdf5", types.NUMPY_DICT, False, chunk_size=50)
+        self._do_open("test_out_single.hdf5")
+        self._do_open("test_out.hdf5")
 
     def testHdf5LoopbackWithJaxArray(self):
-        """ Test writing / reading astropy tables to HDF5 with a jax array """
-        self._do_loopback_jax('test_out', 'hdf5')
-        
+        """Test writing / reading astropy tables to HDF5 with a jax array"""
+        self._do_loopback_jax("test_out", "hdf5")
+
     def testH5Loopback(self):
-        """ Test writing / reading pandas dataframes to HDF5 """
-        self._do_loopback(types.PD_DATAFRAME, 'test_out', 'h5')
-        self._do_loopback_single(types.PD_DATAFRAME, 'test_out_single', 'h5')
-        self._do_iterator('test_out_single.h5', types.PD_DATAFRAME, True, chunk_size=50)
-        self._do_open('test_out_single.h5')
-        self._do_open('test_out.h5')
-        
+        """Test writing / reading pandas dataframes to HDF5"""
+        self._do_loopback(types.PD_DATAFRAME, "test_out", "h5")
+        self._do_loopback_single(types.PD_DATAFRAME, "test_out_single", "h5")
+        self._do_iterator("test_out_single.h5", types.PD_DATAFRAME, True, chunk_size=50)
+        self._do_open("test_out_single.h5")
+        self._do_open("test_out.h5")
+
     def testPQLoopback(self):
-        """ Test writing / reading pandas dataframes to parquet """
-        self._do_loopback_with_keys(types.PD_DATAFRAME, 'test_out', 'pq', list(self._tables.keys()))
-        self._do_loopback_with_keys(types.PD_DATAFRAME, 'test_out', 'pq', ['data'])
-        self._do_loopback_with_keys(types.PD_DATAFRAME, 'test_out', 'pq', ['md'])
-        self._do_loopback_with_keys(types.PD_DATAFRAME, 'test_out', 'pq', ['data'], columns=['scalar'])
-        self._do_loopback_with_keys(types.PD_DATAFRAME, 'test_out', 'pq', ['md'], columns=['a'])
-        # self._do_loopback(types.PD_DATAFRAME, 'test_out', 'pq', ['data','md'], columns={'md':['a'],'data':['scalar']})
-        self._do_loopback_single(types.PD_DATAFRAME, 'test_out_single', 'pq', [''])
-        self._do_iterator('test_out_single.pq', types.PD_DATAFRAME, chunk_size=50)
-        self._do_iterator('test_out_single.pq', types.PD_DATAFRAME, chunk_size=50, columns=['scalar'])
-        self._do_open('test_out_single.pq')
-        
-    def testBad(self):  #pylint: disable=no-self-use
-        """ Test that bad calls to write are dealt with """
+        """Test writing / reading pandas dataframes to parquet"""
+        self._do_loopback_with_keys(types.PD_DATAFRAME, "test_out", "pq", list(self._tables.keys()))
+        self._do_loopback_with_keys(types.PD_DATAFRAME, "test_out", "pq", ["data"])
+        self._do_loopback_with_keys(types.PD_DATAFRAME, "test_out", "pq", ["md"])
+        self._do_loopback_with_keys(types.PD_DATAFRAME, "test_out", "pq", ["data"], columns=["scalar"])
+        self._do_loopback_with_keys(types.PD_DATAFRAME, "test_out", "pq", ["md"], columns=["a"])
+        self._do_loopback_with_keys(types.PD_DATAFRAME, 'test_out', 'pq', ['data','md'], columns={'md':['a'],'data':['scalar']})
+        self._do_loopback_single(types.PD_DATAFRAME, "test_out_single", "pq", [""])
+        self._do_iterator("test_out_single.pq", types.PD_DATAFRAME, chunk_size=50)
+        self._do_iterator("test_out_single.pq", types.PD_DATAFRAME, chunk_size=50, columns=["scalar"])
+        self._do_open("test_out_single.pq")
+
+    def testBad(self):  # pylint: disable=no-self-use
+        """Test that bad calls to write are dealt with"""
         try:
-            write('aa', 'null', 'fits')
+            write("aa", "null", "fits")
         except TypeError:
             pass
         else:
             raise TypeError("Failed to catch unwritable type")
-        assert write(False, 'null', 'fits') is None
+        assert write(False, "null", "fits") is None
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds plumbing and testing explicitly for parquet files. Other file types can follow.