### PR TITLE
quick fix for empty groupname

### DIFF
--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -607,7 +607,7 @@ def readHdf5Group(filepath, groupname=None):
         The input file (returned so that the used can explicitly close the file)
     """
     infp = h5py.File(filepath, "r")
-    if groupname is None:  # pragma: no cover
+    if groupname is None or not groupname:  # pragma: no cover
         return infp, infp
     return infp[groupname], infp
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
