### PR TITLE
87 add functionality to use input iterator in rail for parquet files

### DIFF
--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -1167,7 +1167,7 @@ def getInputDataLength(filepath, fmt=None, **kwargs):
         return theFunc(filepath, **kwargs)
     except KeyError as msg:
         raise NotImplementedError(
-            f"Unsupported FileType for iterateNative {fType}"
+            f"Unsupported FileType for getInputDataLength {fType}"
         ) from msg  # pragma: no cover
 
 

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -417,7 +417,9 @@ def iterH5ToDataFrame(filepath, chunk_size=100_000, groupname=None):
     # infp.close()
 
 
-def iterPqToDataFrame(filepath, chunk_size=100_000, columns=None, **kwargs):
+### I B. Parquet partial read/write functions
+
+def iterPqToDataFrame(filepath, chunk_size=100_000, columns=None, rank=0, parallel_size=1, **kwargs):
     """
     iterator for sending chunks of data in parquet
 
@@ -438,15 +440,54 @@ def iterPqToDataFrame(filepath, chunk_size=100_000, columns=None, **kwargs):
     data: `pandas.DataFrame`
         data frame of all data from start:end
     """
-    parquet_file = pq.read_table(filepath, columns=columns, **kwargs)
+    if rank >= parallel_size:
+        raise TypeError(
+            f"MPI rank {rank} larger than the total " f"number of processes {parallel_size}"
+        )  # pragma: no cover
+
+    num_rows = getInputDataLengthPq(filepath, columns=columns)
+    ranges = data_ranges_by_rank(num_rows, chunk_size, parallel_size, rank)
+
+    parquet_file = pq.read_table(filepath, columns=columns)
     start = 0
     end = 0
-    for table_chunk in parquet_file.to_batches(max_chunksize=chunk_size):
+
+    batches = parquet_file.to_batches(max_chunksize=chunk_size)
+
+    for table_chunk in batches:
         data = pa.Table.from_batches([table_chunk]).to_pandas()
         num_rows = len(data)
         end += num_rows
         yield start, end, data
         start += num_rows
+
+def getInputDataLengthPq(filepath, columns=None, **kwargs):
+    """Open a Parquet file and return the size of a group
+
+    Parameters
+    ----------
+    filepath: `str`
+        Path to input file
+
+    groupname : `str` or `None`
+        The groupname for the data
+
+
+    Returns
+    -------
+    length : `int`
+        The length of the data
+
+    Notes
+    -----
+    For a multi-D array this return the length of the first axis
+    and not the total size of the array.
+
+    Normally that is what you want to be iterating over.
+    """
+    tab = pq.read_table(filepath, columns=columns)
+    nrow = len(tab[tab.column_names[0]])
+    return nrow
 
 
 ### II.   Reading and Writing Files
@@ -1088,6 +1129,38 @@ def iteratorNative(filepath, fmt=None, **kwargs):
     """
     fType = fileType(filepath, fmt)
     funcDict = {NUMPY_HDF5: iterHdf5ToDict, PANDAS_HDF5: iterH5ToDataFrame, PANDAS_PARQUET: iterPqToDataFrame}
+
+    try:
+        theFunc = funcDict[fType]
+        return theFunc(filepath, **kwargs)
+    except KeyError as msg:
+        raise NotImplementedError(
+            f"Unsupported FileType for iterateNative {fType}"
+        ) from msg  # pragma: no cover
+
+
+def getInputDataLength(filepath, fmt=None, **kwargs):
+    """Read a file to the corresponding table type and iterate over the file
+
+    Parameters
+    ----------
+    filepath : `str`
+        File to load
+    fmt : `str` or `None`
+        File format, if `None` it will be taken from the file extension
+
+    Returns
+    -------
+    data : `TableLike`
+        The data
+
+    Notes
+    -----
+    The kwargs are used passed to the specific iterator type
+
+    """
+    fType = fileType(filepath, fmt)
+    funcDict = {NUMPY_HDF5: getInputDataLengthHdf5, PANDAS_HDF5: getInputDataLengthHdf5, PANDAS_PARQUET: getInputDataLengthPq}
 
     try:
         theFunc = funcDict[fType]

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -45,9 +45,11 @@ def test_get_input_data_length():
     """Test the get_input_data_size function"""
     assert io.getInputDataLength(parquet_data_file) == 10
     assert io.getInputDataLength(no_group_file) == 10
+    with pytest.raises(NotImplementedError):
+        io.getInputDataLength("dummy.fits") 
 
 @pytest.mark.skipif(not check_deps([pq]), reason="Missing parquet")
-def test_get_input_data_length():
+def test_get_input_data_length_pq():
     """Test the get_input_data_size_pq function"""
     assert io.getInputDataLengthPq(parquet_data_file) == 10
 

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -40,6 +40,16 @@ def test_get_input_data_length_hdf5():
     else:
         raise ValueError("Failed to catch ValueError for mismatched column lengths")
 
+@pytest.mark.skipif(not check_deps([h5py, pq]), reason="Missing HDF5 or parquet")
+def test_get_input_data_length():
+    """Test the get_input_data_size function"""
+    assert io.getInputDataLength(parquet_data_file) == 10
+    assert io.getInputDataLength(no_group_file) == 10
+
+@pytest.mark.skipif(not check_deps([pq]), reason="Missing parquet")
+def test_get_input_data_length():
+    """Test the get_input_data_size_pq function"""
+    assert io.getInputDataLengthPq(parquet_data_file) == 10
 
 @pytest.mark.skipif(not check_deps([h5py]), reason="Missing HDF5")
 def test_iter_chunk_hdf5_data():


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
