### PR TITLE
Add support for writing nested dictionaries to HDF5

### DIFF
--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -710,11 +710,13 @@ def writeDictToHdf5(odict, filepath, groupname, **kwargs):
     if groupname is None:  # pragma: no cover
         group = fout
     else:
-        group = fout.create_group(groupname)
+        group = fout.require_group(groupname)
     for key, val in odict.items():
         try:
             if isinstance(val, np.ndarray):
                 group.create_dataset(key, dtype=val.dtype, data=val.data)
+            elif isinstance(val, dict):
+                writeDictToHdf5(val, filepath, f"{group.name}/{key}")
             else:
                 # In the future, it may be better to specifically case for
                 # jaxlib.xla_extension.DeviceArray here. For now, we're

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -689,6 +689,33 @@ def readHdf5GroupToDict(hg, start=None, end=None):
     return OrderedDict([(key, readHdf5DatasetToArray(val, start, end)) for key, val in hg.items()])
 
 
+def readHdf5GroupNames(filepath, parent_groupname=None):
+    """Read and return group from an hdf5 file.
+
+    Parameters
+    ----------
+    filepath : `str`
+        File in question
+    parent_groupname : `str` or `None`
+        For hdf5 files, the parent groupname. All group names under this will be
+        returned. If `None`, return the top level group names.
+
+    Returns
+    -------
+    names : `list` of `str`
+        The names of the groups in the file
+    """
+    infp = h5py.File(filepath, "r")
+    if parent_groupname is None:  # pragma: no cover
+        return list(infp.keys())
+
+    try:
+        subgroups = infp[parent_groupname].keys()
+    except KeyError as msg:
+        raise KeyError(f"Group {parent_groupname} not found in file {filepath}") from msg
+    return list(subgroups)
+
+
 def writeDictToHdf5(odict, filepath, groupname, **kwargs):
     """
     Writes a dictionary of `numpy.array` or `jaxlib.xla_extension.DeviceArray`

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -135,6 +135,39 @@ def test_write_output_file_single():
 
 
 @pytest.mark.skipif(not check_deps([h5py]), reason="Missing HDF5")
+def test_get_group_names():
+    """Create a mock file with some data, ensure that the group names are read correctly."""
+    npdf = 40
+    nbins = 21
+    pz_pdf = np.random.uniform(size=(npdf, nbins))
+    zgrid = np.linspace(0, 4, nbins)
+    zmode = zgrid[np.argmax(pz_pdf, axis=1)]
+
+    data_dict = dict(zmode=zmode, pz_pdf=pz_pdf)
+
+    group, outf = io.initializeHdf5WriteSingle(
+        test_outfile, None, photoz_mode=((npdf,), "f4"), photoz_pdf=((npdf, nbins), "f4")
+    )
+    io.writeDictToHdf5ChunkSingle(group, data_dict, 0, npdf, zmode="photoz_mode", pz_pdf="photoz_pdf")
+    io.finalizeHdf5Write(outf, "md", zgrid=zgrid)
+
+    group_names = io.readHdf5GroupNames(test_outfile)
+    assert len(group_names) == 3
+    assert "md" in group_names
+    assert "photoz_mode" in group_names
+    assert "photoz_pdf" in group_names
+
+    subgroup_names = io.readHdf5GroupNames(test_outfile, "md")
+    assert "zgrid" in subgroup_names
+
+    with pytest.raises(KeyError) as excinfo:
+        _ = io.readHdf5GroupNames(test_outfile, "dummy")
+        assert "dummy" in str(excinfo.value)
+
+    os.unlink(test_outfile)
+
+
+@pytest.mark.skipif(not check_deps([h5py]), reason="Missing HDF5")
 def test_write_output_parallel_file_single():
     from mpi4py import MPI
 

--- a/tests/test_fileIO.py
+++ b/tests/test_fileIO.py
@@ -143,19 +143,16 @@ def test_get_group_names():
     zgrid = np.linspace(0, 4, nbins)
     zmode = zgrid[np.argmax(pz_pdf, axis=1)]
 
-    data_dict = dict(zmode=zmode, pz_pdf=pz_pdf)
+    md_dict = dict(zgrid=zgrid)
+    data_dict = dict(zmode=zmode, pz_pdf=pz_pdf, md=md_dict)
 
-    group, outf = io.initializeHdf5WriteSingle(
-        test_outfile, None, photoz_mode=((npdf,), "f4"), photoz_pdf=((npdf, nbins), "f4")
-    )
-    io.writeDictToHdf5ChunkSingle(group, data_dict, 0, npdf, zmode="photoz_mode", pz_pdf="photoz_pdf")
-    io.finalizeHdf5Write(outf, "md", zgrid=zgrid)
+    io.writeDictToHdf5(data_dict, test_outfile, groupname=None)
 
     group_names = io.readHdf5GroupNames(test_outfile)
     assert len(group_names) == 3
     assert "md" in group_names
-    assert "photoz_mode" in group_names
-    assert "photoz_pdf" in group_names
+    assert "zmode" in group_names
+    assert "pz_pdf" in group_names
 
     subgroup_names = io.readHdf5GroupNames(test_outfile, "md")
     assert "zgrid" in subgroup_names


### PR DESCRIPTION
Initial attempt to add support for nested dictionaries with numpy array values.

## Problem & Solution Description (including issue #)
The goal is to be able to write out to an hdf5 file a structure that mirrors a nested dictionary where the leaf values are all numpy arrays. The current approach introduces a bit of recursion into the `writeDictToHdf5` file. Still need to write a good handful of tests. 

The specific use case here should support the following:

```
def write_dict(filename, ensemble_dict, **kwargs):
        # ensemble_dict has the form { <str> : <qp.Ensemble> }
        # output_tables has the form { <str> : <tabularized qp.Ensemble> }
        # where a tabularized qp.Ensemble is a dictionary of dicts with leaf values that are numpy arrays.

        output_tables = {}
        for key, val in ensemble_dict.items():
            # check that val is a qp.Ensemble
            if not isinstance(val, Ensemble):
                raise ValueError("All values in ensemble_dict must be qp.Ensemble")

            output_tables[key] = val.build_tables()
        io.writeDictsToHdf5(output_tables, filename, **kwargs)
```

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
