### PR TITLE
Add cli for tables_io.convert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
     "sphinx-autoapi", # Used to automatically generate api documentation
 ]
 
+[project.scripts]
+convert-table = "tables_io.cli:main"
+
 [build-system]
 requires = [
     "setuptools>=62", # Used to build and package the Python project

--- a/src/tables_io/cli.py
+++ b/src/tables_io/cli.py
@@ -1,0 +1,41 @@
+"""cli for tables_io.convert"""
+
+import argparse
+
+import tables_io
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "input",
+        type=str,
+        help=f"input filename; suffix should be one of {list(tables_io.types.FILE_FORMAT_SUFFIXS.keys())}",
+    )
+    parser.add_argument(
+        "output",
+        type=str,
+        help=f"output filename; suffix should be one of {list(tables_io.types.FILE_FORMAT_SUFFIXS.keys())}",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    input_fname = args.input
+    output_fname = args.output
+    output_format = output_fname.split(".")[-1]
+
+    print(f"Converting {input_fname} to {output_fname}")
+
+    suffixes = tables_io.types.FILE_FORMAT_SUFFIXS
+    suffix = suffixes[output_format]
+
+    t_in = tables_io.read(input_fname)
+    t_out = tables_io.convert(t_in, suffix)
+    written = tables_io.write(t_out, output_fname)
+
+    print(f"Done converting file")
+
+    return 0


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

This adds a light command line interface to tables_io.convert to facilitate converting to/form formats supported by tables_io. Happy to move the file / make any changes as necessary.


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
