### PR TITLE
get pa from lazy_modules in types

### DIFF
--- a/src/tables_io/types.py
+++ b/src/tables_io/types.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 from collections.abc import Iterable, Mapping
 
 import numpy as np
-import pyarrow as pa
 
 from .arrayUtils import arrayLength
+from .lazy_modules import pa
 
 # Tabular data formats
 AP_TABLE = 0


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
