### PR TITLE
Issue/102/check columns

### DIFF
--- a/src/tables_io/__init__.py
+++ b/src/tables_io/__init__.py
@@ -43,3 +43,5 @@ concat = concatUtils.concat
 sliceObj = sliceUtils.sliceObj
 
 sliceObjs = sliceUtils.sliceObjs
+
+check_columns = io.check_columns

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -1634,10 +1634,10 @@ def check_columns(filepath, columns_to_check, fmt=None, **kwargs):
                 if col.name not in col_list:
                     col_list.append(col.name)
 
-    if fType in [ASTROPY_HDF5, NUMPY_HDF5, PANDAS_HDF5, PYARROW_HDF5]:
+    elif fType in [ASTROPY_HDF5, NUMPY_HDF5, PANDAS_HDF5, PYARROW_HDF5]:
         col_list = readHdf5GroupNames(filepath, **kwargs)
 
-    if fType in [PYARROW_PARQUET, PANDAS_PARQUET]:
+    elif fType in [PYARROW_PARQUET, PANDAS_PARQUET]:
         col_list = file.schema.names
     else:
         raise TypeError(f"Unsupported FileType {fType}")  # pragma: no cover

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -1629,7 +1629,7 @@ def check_columns(filepath, columns_to_check, fmt=None, **kwargs):
     if fType in [ASTROPY_FITS, NUMPY_FITS]:
         col_list=[]
         for hdu in file[1:]:
-            columns = hdu.colums
+            columns = hdu.columns
             for col in columns:
                 if col.name not in col_list:
                     col_list.append(col.name)

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -1602,3 +1602,38 @@ def write(obj, filepath, fmt=None):
         return filepath    
 
     raise TypeError(f"Unsupported File type {fType}")  # pragma: no cover
+
+    
+
+    
+def check_columns(filepath, columns_to_check, fmt=None):
+    """Read the file column names and check it against input list
+
+    Parameters
+    ----------
+    filepath : `str`
+        File name for the file to read. If there's no suffix, it will be applied based on the object type.
+    columns_to_check: `list`
+        A list of columns to be compared with the data
+    fmt : `str` or `None`
+        The output file format, If `None` this will use `writeNative`
+    """
+    
+    if fmt is None:
+        splitpath = os.path.splitext(filepath)
+        if not splitpath[1]:
+            return writeNative(obj, filepath)
+        fmt = splitpath[1][1:]
+
+    try:
+        fType = FILE_FORMAT_SUFFIXS[fmt]
+    except KeyError as msg:  # pragma: no cover
+        raise KeyError(f"Unknown file format {fmt} from {filepath}, options are {list(FILE_FORMAT_SUFFIXS.keys())}") from msg
+        
+    # now we need to consider each case separately below:
+    
+    # for each case, only need to read the header / groupname / column name rather than full dataset:
+    
+    
+    
+    return 

--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -1644,7 +1644,7 @@ def check_columns(filepath, columns_to_check, fmt=None, **kwargs):
 
     # check columns
     intersection = set(columns_to_check).intersection(col_list)
-    if len(intersection)<columns_to_check:
+    if len(intersection)<len(columns_to_check):
         diff = set(columns_to_check) - intersection
         raise KeyError("The following columns are not found: ", diff)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -202,7 +202,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.h5", types.PD_DATAFRAME, True, chunk_size=50)
         self._do_open("test_out_single.h5")
         self._do_open("test_out.h5")
-        self._do_check_columns("test_out.hd5")
+        self._do_check_columns("test_out.h5")
 
     def testPQLoopback(self):
         """Test writing / reading pandas dataframes to parquet"""

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 import unittest
-from tables_io import types, convert, io_open, read, write, iterator
+from tables_io import types, convert, io_open, read, write, iterator, check_columns
 from tables_io.testUtils import compare_table_dicts, compare_tables, make_test_data, check_deps
 from tables_io.lazy_modules import apTable, jnp, h5py, pd, pq
 
@@ -131,6 +131,14 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         with io_open(filepath) as f:
             assert f
 
+    def _do_check_columns(self, filepath):
+        columns_to_check=['imaginary_column']
+        try:
+            check_columns(filepath, columns_to_check)
+        except KeyError:
+            pass
+
+
     def testFitsLoopback(self):
         """Test writing / reading to FITS"""
         self._do_loopback(types.AP_TABLE, "test_out", "fits")
@@ -139,6 +147,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.fits", types.AP_TABLE, True)
         self._do_open("test_out_single.fits")
         self._do_open("test_out.fits")
+        self._do_check_columns("test_out.fits")
 
     def testRecarrayLoopback(self):
         """Test writing / reading to FITS"""
@@ -148,6 +157,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.fit", types.NUMPY_RECARRAY, True)
         self._do_open("test_out_single.fit")
         self._do_open("test_out.fit")
+        self._do_check_columns("test_out.fit")
 
     def testHf5Loopback(self):
         """Test writing / reading astropy tables to HDF5"""
@@ -157,6 +167,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.hf5", types.AP_TABLE, True, chunk_size=50)
         self._do_open("test_out_single.hf5")
         self._do_open("test_out.hf5")
+        self._do_check_columns("test_out.hf5")
 
     def testHdf5Loopback(self):
         """Test writing / reading numpy arrays to HDF5"""
@@ -166,6 +177,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.hdf5", types.NUMPY_DICT, False, chunk_size=50)
         self._do_open("test_out_single.hdf5")
         self._do_open("test_out.hdf5")
+        self._do_check_columns("test_out.hdf5")
 
     def testHd5Loopback(self):
         """Test pyarrow tables to HDF5"""
@@ -175,6 +187,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         #self._do_iterator("test_out_single.hd5", types.PA_TABLE, False, chunk_size=50)
         self._do_open("test_out_single.hd5")
         self._do_open("test_out.hd5")
+        self._do_check_columns("test_out.hd5")
 
     def testHdf5LoopbackWithJaxArray(self):
         """Test writing / reading astropy tables to HDF5 with a jax array"""
@@ -189,6 +202,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.h5", types.PD_DATAFRAME, True, chunk_size=50)
         self._do_open("test_out_single.h5")
         self._do_open("test_out.h5")
+        self._do_check_columns("test_out.hd5")
 
     def testPQLoopback(self):
         """Test writing / reading pandas dataframes to parquet"""
@@ -206,6 +220,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_iterator("test_out_single.pq", types.PD_DATAFRAME, chunk_size=50)
         self._do_iterator("test_out_single.pq", types.PD_DATAFRAME, chunk_size=50, columns=["scalar"])
         self._do_open("test_out_single.pq")
+        self._do_check_columns("test_out_single.pq")
 
     def testParquetLoopback(self):
         """Test writing / reading pyarros tables to parquet files"""
@@ -213,6 +228,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         self._do_loopback_single(types.PA_TABLE, "test_out_single", "parquet", [""])
         self._do_iterator("test_out_single.parquet", types.PA_TABLE, True, chunk_size=50)
         self._do_open("test_out_single.parquet")
+        self._do_check_columns("test_out_single.parquet")
 
     def testBad(self):  # pylint: disable=no-self-use
         """Test that bad calls to write are dealt with"""
@@ -223,6 +239,7 @@ class IoTestCase(unittest.TestCase):  # pylint: disable=too-many-instance-attrib
         else:
             raise TypeError("Failed to catch unwritable type")
         assert write(False, "null", "fits") is None
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
As described in #102, the PR adds a function in tables io to check if a given list of column names exist in the input data file.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
