### PR TITLE
making the hdf5 groupname args explicit

### DIFF
--- a/src/tables_io/ioUtils.py
+++ b/src/tables_io/ioUtils.py
@@ -1606,7 +1606,7 @@ def write(obj, filepath, fmt=None):
     
 
     
-def check_columns(filepath, columns_to_check, fmt=None, **kwargs):
+def check_columns(filepath, columns_to_check, fmt=None, parent_groupname=None, **kwargs):
     """Read the file column names and check it against input list
 
     Parameters
@@ -1635,7 +1635,7 @@ def check_columns(filepath, columns_to_check, fmt=None, **kwargs):
                     col_list.append(col.name)
 
     elif fType in [ASTROPY_HDF5, NUMPY_HDF5, PANDAS_HDF5, PYARROW_HDF5]:
-        col_list = readHdf5GroupNames(filepath, **kwargs)
+        col_list = readHdf5GroupNames(filepath, parent_groupname=parent_groupname)
 
     elif fType in [PYARROW_PARQUET, PANDAS_PARQUET]:
         col_list = file.schema.names


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
A fix to #102 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
